### PR TITLE
Add utilities object for QueryT specializations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,9 @@ val commonSettings = Seq(
   )),
   resolvers ++= Seq[Resolver](
     Resolver.sonatypeRepo("releases")
+  ),
+  addCompilerPlugin(
+    "org.spire-math" % "kind-projector" % "0.9.8" cross CrossVersion.binary
   )
 )
 

--- a/core/src/main/scala/core/database/QueryE.scala
+++ b/core/src/main/scala/core/database/QueryE.scala
@@ -1,0 +1,38 @@
+package com.zengularity.querymonad.core.database
+
+import cats.instances.either.catsStdInstancesForEither
+
+object QueryE {
+  def apply[Resource, Err, A](
+      run: Resource => Either[Err, A]
+  ): QueryE[Resource, Err, A] =
+    QueryT.apply[Either[Err, ?], Resource, A](run)
+
+  def pure[Resource, Err, A](
+      a: A
+  ) =
+    QueryT.pure[Either[Err, ?], Resource, A](a)
+
+  def ask[Resource, Err] =
+    QueryT.ask[Either[Err, ?], Resource]
+
+  def liftF[Resource, Err, A](either: Either[Err, A]) =
+    QueryT.liftF[Either[Err, ?], Resource, A](either)
+
+  def lift[Resource, Err, A](
+      query: Query[Resource, A]
+  ) =
+    QueryE[Resource, Err, A](query.map(catsStdInstancesForEither.pure).run)
+
+  def fromQuery[Resource, Err, A](
+      query: Query[Resource, Either[Err, A]]
+  ): QueryE[Resource, Err, A] =
+    QueryE[Resource, Err, A](query.run)
+
+  def liftQuery[Resource, Err, A](
+      query: Query[Resource, A]
+  ): QueryE[Resource, Err, A] =
+    QueryE.fromQuery[Resource, Err, A](
+      query.map(catsStdInstancesForEither.pure)
+    )
+}

--- a/core/src/main/scala/core/database/QueryList.scala
+++ b/core/src/main/scala/core/database/QueryList.scala
@@ -1,0 +1,36 @@
+package com.zengularity.querymonad.core.database
+
+import cats.instances.list.catsStdInstancesForList
+
+object QueryList {
+  def apply[Resource, A](
+      run: Resource => List[A]
+  ): QueryList[Resource, A] =
+    QueryT.apply[List, Resource, A](run)
+
+  def pure[Resource, A](a: A) =
+    QueryT.pure[List, Resource, A](a)
+
+  def ask[Resource] =
+    QueryT.ask[List, Resource]
+
+  def liftF[Resource, A](list: List[A]) =
+    QueryT.liftF[List, Resource, A](list)
+
+  def lift[Resource, A](
+      query: Query[Resource, A]
+  ) =
+    QueryList[Resource, A](query.map(catsStdInstancesForList.pure).run)
+
+  def fromQuery[Resource, A](
+      query: Query[Resource, List[A]]
+  ): QueryList[Resource, A] =
+    QueryList[Resource, A](query.run)
+
+  def liftQuery[Resource, A](
+      query: Query[Resource, A]
+  ): QueryList[Resource, A] =
+    QueryList.fromQuery[Resource, A](
+      query.map(catsStdInstancesForList.pure)
+    )
+}

--- a/core/src/main/scala/core/database/QueryO.scala
+++ b/core/src/main/scala/core/database/QueryO.scala
@@ -1,0 +1,36 @@
+package com.zengularity.querymonad.core.database
+
+import cats.instances.option.catsStdInstancesForOption
+
+object QueryO {
+  def apply[Resource, A](
+      run: Resource => Option[A]
+  ): QueryO[Resource, A] =
+    QueryT.apply[Option, Resource, A](run)
+
+  def pure[Resource, A](a: A) =
+    QueryT.pure[Option, Resource, A](a)
+
+  def ask[Resource] =
+    QueryT.ask[Option, Resource]
+
+  def liftF[Resource, A](option: Option[A]) =
+    QueryT.liftF[Option, Resource, A](option)
+
+  def lift[Resource, A](
+      query: Query[Resource, A]
+  ) =
+    QueryO[Resource, A](query.map(catsStdInstancesForOption.pure).run)
+
+  def fromQuery[Resource, A](
+      query: Query[Resource, Option[A]]
+  ): QueryO[Resource, A] =
+    QueryO[Resource, A](query.run)
+
+  def liftQuery[Resource, A](
+      query: Query[Resource, A]
+  ): QueryO[Resource, A] =
+    QueryO.fromQuery[Resource, A](
+      query.map(catsStdInstancesForOption.pure)
+    )
+}

--- a/core/src/main/scala/core/database/package.scala
+++ b/core/src/main/scala/core/database/package.scala
@@ -56,5 +56,5 @@ package object database {
   type QueryO[Resource, A] = QueryT[Option, Resource, A]
 
   type QueryE[Resource, Err, A] =
-    QueryT[({ type F[T] = Either[Err, T] })#F, Resource, A]
+    QueryT[Either[Err, ?], Resource, A]
 }

--- a/core/src/main/scala/core/database/package.scala
+++ b/core/src/main/scala/core/database/package.scala
@@ -55,6 +55,8 @@ package object database {
 
   type QueryO[Resource, A] = QueryT[Option, Resource, A]
 
+  type QueryList[Resource, A] = QueryT[List, Resource, A]
+
   type QueryE[Resource, Err, A] =
     QueryT[Either[Err, ?], Resource, A]
 }

--- a/core/src/main/scala/module/sql/SqlQueryE.scala
+++ b/core/src/main/scala/module/sql/SqlQueryE.scala
@@ -1,0 +1,28 @@
+package com.zengularity.querymonad.module.sql
+
+import java.sql.Connection
+
+import com.zengularity.querymonad.core.database.QueryE
+
+object SqlQueryE {
+  def apply[Err, A](run: Connection => Either[Err, A]) =
+    QueryE.apply[Connection, Err, A](run)
+
+  def pure[Err, A](a: A) =
+    QueryE.pure[Connection, Err, A](a)
+
+  def ask[Err] =
+    QueryE.ask[Connection, Err]
+
+  def liftF[Err, A](option: Either[Err, A]) =
+    QueryE.liftF[Connection, Err, A](option)
+
+  def lift[Err, A](query: SqlQuery[A]) =
+    QueryE.lift[Connection, Err, A](query)
+
+  def fromQuery[Err, A](query: SqlQuery[Either[Err, A]]) =
+    QueryE.fromQuery[Connection, Err, A](query)
+
+  def liftQuery[Err, A](query: SqlQuery[A]) =
+    QueryE.liftQuery[Connection, Err, A](query)
+}

--- a/core/src/main/scala/module/sql/SqlQueryList.scala
+++ b/core/src/main/scala/module/sql/SqlQueryList.scala
@@ -1,0 +1,26 @@
+package com.zengularity.querymonad.module.sql
+
+import java.sql.Connection
+
+import com.zengularity.querymonad.core.database.QueryList
+
+object SqlQueryList {
+  def apply[A](run: Connection => List[A]) =
+    QueryList.apply[Connection, A](run)
+
+  def pure[A](a: A) =
+    QueryList.pure[Connection, A](a)
+
+  def ask = QueryList.ask[Connection]
+
+  def liftF[A](list: List[A]) = QueryList.liftF[Connection, A](list)
+
+  def lift[A](query: SqlQuery[A]) =
+    QueryList.lift[Connection, A](query)
+
+  def fromQuery[A](query: SqlQuery[List[A]]) =
+    QueryList.fromQuery[Connection, A](query)
+
+  def liftQuery[A](query: SqlQuery[A]) =
+    QueryList.liftQuery[Connection, A](query)
+}

--- a/core/src/main/scala/module/sql/SqlQueryO.scala
+++ b/core/src/main/scala/module/sql/SqlQueryO.scala
@@ -1,0 +1,26 @@
+package com.zengularity.querymonad.module.sql
+
+import java.sql.Connection
+
+import com.zengularity.querymonad.core.database.QueryO
+
+object SqlQueryO {
+  def apply[A](run: Connection => Option[A]) =
+    QueryO.apply[Connection, A](run)
+
+  def pure[A](a: A) =
+    QueryO.pure[Connection, A](a)
+
+  def ask = QueryO.ask[Connection]
+
+  def liftF[A](option: Option[A]) = QueryO.liftF[Connection, A](option)
+
+  def lift[A](query: SqlQuery[A]) =
+    QueryO.lift[Connection, A](query)
+
+  def fromQuery[A](query: SqlQuery[Option[A]]) =
+    QueryO.fromQuery[Connection, A](query)
+
+  def liftQuery[A](query: SqlQuery[A]) =
+    QueryO.liftQuery[Connection, A](query)
+}

--- a/core/src/main/scala/module/sql/package.scala
+++ b/core/src/main/scala/module/sql/package.scala
@@ -46,7 +46,7 @@ package object sql {
     def lift[M[_], A](
         query: SqlQuery[A]
     )(implicit F: Applicative[M]) =
-      SqlQueryT[M, A](query.map(F.pure).run)
+      QueryT.lift[M, Connection, A](query)
 
     def fromQuery[M[_], A](query: SqlQuery[M[A]]) =
       QueryT.fromQuery[M, Connection, A](query)
@@ -57,7 +57,7 @@ package object sql {
 
   type SqlQueryO[A] = QueryO[Connection, A]
 
-  type SqlQueryE[A, Err] = QueryE[Connection, A, Err]
+  type SqlQueryE[A, Err] = QueryE[Connection, Err, A]
 
   // Query runner aliases
   type WithSqlConnection = WithResource[Connection]


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guide](CONTRIBUTING.md)?
* [ ] Have you added tests for any changed functionality?

## Fixes

N/A

## Purpose

This PR adds companion objects to the `QueryO` and `QueryE` types. The contents of these objects are functions  forwarding their implementation to the ones in `QueryT`.
It also adds a specialization of `QueryT` for the `List` type, with a companion object.

## Background Context

As discussed collectively.

## References

N/A
